### PR TITLE
Removes memory leaks and global variable from get_next_line

### DIFF
--- a/libft/ft_io/get_next_line.c
+++ b/libft/ft_io/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/29 16:56:03 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/12/21 20:34:37 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2023/01/20 21:14:27 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,61 +16,59 @@
 #include <libft/ft_string.h>
 #include <libft/ft_io/get_next_line.h>
 
-static char	*g_saves[OPEN_MAX] = {};
-
-int	found_linebreak(int fd)
+static int	found_linebreak(char *save)
 {
-	if (g_saves[fd] == NULL)
+	if (save == NULL)
 		return (0);
-	return ((ft_strchr(g_saves[fd], '\n') != NULL));
+	return ((ft_strchr(save, '\n') != NULL));
 }
 
-int	read_chunk(int fd)
+static int	read_chunk(int fd, char **save)
 {
-	char	*buf;
-	char	*save;
+	char	*temp;
 	ssize_t	bytes_read;
+	char	buf[BUFFER_SIZE + 1];
 
-	buf = ft_calloc(1, BUFFER_SIZE + 1);
-	if (buf == NULL)
-		return (1);
+	ft_bzero(buf, BUFFER_SIZE + 1);
 	bytes_read = read(fd, buf, BUFFER_SIZE);
 	if (bytes_read < 0)
 		return (GNLERROR);
 	if (bytes_read == 0)
 		return (GNLEOF);
-	if (g_saves[fd] == NULL)
-		g_saves[fd] = ft_strdup(buf);
+	if (*save == NULL)
+		*save = ft_strdup(buf);
 	else
 	{
-		save = ft_strjoin(g_saves[fd], buf);
-		free(g_saves[fd]);
-		if (save == NULL)
+		temp = ft_strjoin(*save, buf);
+		free(*save);
+		*save = temp;
+		if (*save == NULL)
 			return (GNLERROR);
-		g_saves[fd] = save;
 	}
 	return (0);
 }
 
-char	*get_line(int fd)
+char	*get_line(char **save)
 {
+	char	*temp;
 	char	*line;
 	char	*linebreak;
+	size_t	line_size;
 
-	if (g_saves[fd] == NULL)
+	if (*save == NULL)
 		return (NULL);
-	linebreak = ft_strchr(g_saves[fd], '\n');
-	if (linebreak == NULL || linebreak[1] == '\0')
-	{
-		line = ft_strdup(g_saves[fd]);
-		free(g_saves[fd]);
-		g_saves[fd] = NULL;
-	}
-	else
-	{
-		line = ft_substr(g_saves[fd], 0, linebreak - g_saves[fd] + 1);
-		ft_strlcpy(g_saves[fd], linebreak + 1, linebreak - g_saves[fd] + 1);
-	}
+	temp = NULL;
+	linebreak = ft_strchr(*save, '\n');
+	line_size = ft_strlen(*save);
+	if (linebreak != NULL && linebreak[1] != '\0')
+		line_size = line_size - ft_strlen(linebreak + 1);
+	line = ft_substr(*save, 0, line_size);
+	if ((ft_strlen(*save + line_size) > 0))
+		temp = ft_strdup(*save + line_size);
+	free(*save);
+	*save = NULL;
+	if (temp != NULL)
+		*save = temp;
 	return (line);
 }
 
@@ -81,35 +79,24 @@ char	*get_line(int fd)
  */
 char	*get_next_line(int fd)
 {
-	int		status;
-	char	*line;
+	int			status;
+	char		*line;
+	static char	*saves[OPEN_MAX];
 
 	if (fd < 0)
 		return (NULL);
-	while ((found_linebreak(fd) == 0))
+	while ((found_linebreak(saves[fd]) == 0))
 	{
-		status = read_chunk(fd);
+		status = read_chunk(fd, &(saves[fd]));
 		if (status == GNLERROR)
+		{
+			free(saves[fd]);
+			saves[fd] = NULL;
 			return (NULL);
+		}
 		if (status == GNLEOF)
 			break ;
 	}
-	line = get_line(fd);
+	line = get_line(&(saves[fd]));
 	return (line);
-}
-
-void	gnl_clear(void)
-{
-	size_t	fd;
-
-	fd = 0;
-	while (fd < OPEN_MAX)
-	{
-		if (g_saves[fd] != NULL)
-		{
-			free(g_saves[fd]);
-			g_saves[fd] = NULL;
-		}
-		fd++;
-	}
 }

--- a/libft/ft_io/get_next_line.h
+++ b/libft/ft_io/get_next_line.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line.h                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vgoncalv <vgoncalv>                        +#+  +:+       +#+        */
+/*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 15:58:41 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/09/04 16:05:00 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2023/01/20 21:13:33 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,6 @@ enum e_gnlstatus
 	GNLERROR = 1,
 	GNLEOF,
 };
-
-void	gnl_clear(void);
 
 char	*get_next_line(int fd);
 


### PR DESCRIPTION
### Changes
- Removes "global" variable `g_saves` (it's scope is actually the file, but I
  think it breaks the Norme rules)
- `buf` now uses stack memory allocation
